### PR TITLE
Converted getPos to getPosATL

### DIFF
--- a/addons/sp_entities/functions/actions/fn_save.sqf
+++ b/addons/sp_entities/functions/actions/fn_save.sqf
@@ -36,7 +36,7 @@ _entityObjects = entities [_SPEExclusionArray, _SPEInclusionArray, _SPEIncludeCr
 			_objectType = typeof _x;
 			_objectGroup = group _x;
 			_objectContents = getUnitLoadout _x;
-			_objectpos = getpos _x;
+			_objectpos = getposATL _x;
 			_objectHealth = getAllHitPointsDamage _x;
 
 			[3, format["Found unit of type: %1, pos: %2, health: %3, contents: %4", _objectType, _objectpos, _objectHealth, _objectContents], _filename] call spp_fnc_log;
@@ -47,7 +47,7 @@ _entityObjects = entities [_SPEExclusionArray, _SPEInclusionArray, _SPEIncludeCr
 			_objectType = typeof _x;
 			_objectGroup = group vehicle _x;
 			_objectContents = [_x] call spe_fnc_getVehLoadout; 
-			_objectpos = getpos _x;
+			_objectpos = getposATL _x;
 			_objectHealth = getAllHitPointsDamage _x;
 
 			[3, format["Found Vehicle of type: %1, pos: %2, health: %3, contents: %4", _objectType, _objectpos, _objectHealth, _objectContents], _filename] call spp_fnc_log;

--- a/addons/sp_player/functions/sp/fn_getPlayerdata.sqf
+++ b/addons/sp_player/functions/sp/fn_getPlayerdata.sqf
@@ -11,7 +11,7 @@ private _roleid = _player getvariable ["SPRoleID", ""];
 [2, format ["Getting %1 info to save.", _pName]] call spp_fnc_log;
 
 _PLoad = getUnitLoadout _player;
-_PPos = getpos _player;
+_PPos = getposATL _player;
 _pDMG = getAllHitPointsDamage _player;
 _pACERations = [_player] call spp_fnc_getPlayerACERations;
 

--- a/addons/sp_player/functions/sp/fn_setDefaults.sqf
+++ b/addons/sp_player/functions/sp/fn_setDefaults.sqf
@@ -1,6 +1,6 @@
 params ["_player"];
 private _scriptName = "fn_setDefaults";
-private _ppos = getpos _player;
+private _ppos = getposATL _player;
 private _Pid = getplayerUID _player;
 private _pload = [];
 private _pDMG = [];

--- a/addons/sp_player/functions/sp/fn_setobjpos.sqf
+++ b/addons/sp_player/functions/sp/fn_setobjpos.sqf
@@ -9,7 +9,15 @@ if (_ppos isEqualTo [0,0,0]) exitwith {
 [3, format ["Restoring position for %1 at %2", _ObjectName, _ppos], _scriptName] call spp_fnc_log;
 private _safepos = ([_PPos,0,10,5,0] call BIS_fnc_findSafePos);
 
-_safepos set [2, 0]; // Set ground height.
-[3, format["Preferred Position for %1: %2",	_ObjectName, _safepos], _scriptName] call spp_fnc_log;
+// BIS_fnc_findSafePos returns 3 objects in array when it fails, 2 if it succeeds. 
+// If it fails, we'll just set the object to the original position.
+if (count _safepos > 2) then {
+	[1, format ["Failed to find safe position for %1, setting to original position.", _ObjectName], _scriptName] call spp_fnc_log;
+	_safepos = _ppos;
+} else {
+	_safepos set [2, 0]; // Set ground height.
+	[3, format["Preferred Position for %1: %2",	_ObjectName, _safepos], _scriptName] call spp_fnc_log;
+};
+
 [_object, _safepos] remoteexec ["setPosATL", _MID];
 // _object setPos _safepos;


### PR DESCRIPTION
Change and Fix

- Changes the Save & Load defaults to g/setPosATL. 
- Adds a check for when BIS_fnc_findSafePos fails and defaults back to the stored array. This means that players should end up on the floor, the majority of the time and if there's nowhere safe, they're back where they left.

Fixes #2 